### PR TITLE
Add Opera installation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,15 @@ firefox: # Firefox without ppa
 	echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" | sudo tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null
 	echo -e "Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000"| sudo tee /etc/apt/preferences.d/mozilla
 
+opera: # Opera browser via apt repository
+# Source: https://www.ubuntuupdates.org/ppa/opera
+	sudo apt-get install -y wget gpg
+	sudo mkdir -p /etc/apt/keyrings
+	wget -qO- https://deb.opera.com/archive.key | gpg --dearmor | sudo tee /etc/apt/keyrings/opera.gpg > /dev/null
+	echo "deb [signed-by=/etc/apt/keyrings/opera.gpg] https://deb.opera.com/opera-stable/ stable non-free" | sudo tee /etc/apt/sources.list.d/opera.list > /dev/null
+	sudo apt update
+	sudo apt install -y opera-stable
+
 firefox-developer: # Firefox developer edition
 	mkdir -p ~/.local/opt
 	curl -fSL --progress-bar "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64&lang=en-US" -o firefox.tar.bz2

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Use `make` without targets to list all the follow targets:
 | nextcloud-desktop  | Desktop sync client for Nextcloud. Will be good to run the target appimage-launcher                                 |
 | obs-flatpak        | Install OBS Studio from flatpak                                                                                     |
 | onlyoffice-desktop | ONLYOFFICE Desktop                                                                                                  |
+| opera              | Opera browser via apt repository                                                                                    |
 | piper              | Piper - text speech                                                                                                 |
 | slim               | Slim(toolkit). Don't change anything in your container image and minify it by up to 30x making it secure too!       |
 | telegram-flatpak   | Install Telegram from flatpak                                                                                       |


### PR DESCRIPTION
## Summary
- add an `opera` target to `Makefile` using the Opera apt repository
- document the new target in `README.md`

## Validation
- `make help | grep opera`
- `make -n opera`